### PR TITLE
Added filters for invalid characters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ fn get_id_and_title(file: &mut File) -> Result<(String, String), ParseImageError
     file.read_exact(&mut title)?;
     let title = String::from_utf8(title.to_vec())?;
     let title = title.trim_matches(char::from(0)).to_string();
+    let title = title.replace(":", " -");
+    let title = title.replace("?", "");
 
     Ok((id, title))
 }


### PR DESCRIPTION
Added filters to remove `:` and `?` from game titles, which fixes [this bug](https://github.com/mq1/TinyWiiBackupManager/issues/3) in Tiny Wii Backup Manager